### PR TITLE
GPU: Use a bitmap to track buffer modified flags. (#3775)

### DIFF
--- a/Ryujinx.Memory/Tracking/BitMap.cs
+++ b/Ryujinx.Memory/Tracking/BitMap.cs
@@ -1,0 +1,199 @@
+﻿using System.Runtime.CompilerServices;
+
+namespace Ryujinx.Memory.Tracking
+{
+    /// <summary>
+    /// A bitmap that can check or set large ranges of true/false values at once.
+    /// </summary>
+    struct BitMap
+    {
+        public const int IntSize = 64;
+
+        private const int IntShift = 6;
+        private const int IntMask = IntSize - 1;
+
+        /// <summary>
+        /// Masks representing the bitmap. Least significant bit first, 64-bits per mask.
+        /// </summary>
+        public readonly long[] Masks;
+
+        /// <summary>
+        /// Create a new bitmap.
+        /// </summary>
+        /// <param name="count">The number of bits to reserve</param>
+        public BitMap(int count)
+        {
+            Masks = new long[(count + IntMask) / IntSize];
+        }
+
+        /// <summary>
+        /// Check if any bit in the bitmap is set.
+        /// </summary>
+        /// <returns>True if any bits are set, false otherwise</returns>
+        public bool AnySet()
+        {
+            for (int i = 0; i < Masks.Length; i++)
+            {
+                if (Masks[i] != 0)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Check if a bit in the bitmap is set.
+        /// </summary>
+        /// <param name="bit">The bit index to check</param>
+        /// <returns>True if the bit is set, false otherwise</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool IsSet(int bit)
+        {
+            int wordIndex = bit >> IntShift;
+            int wordBit = bit & IntMask;
+
+            long wordMask = 1L << wordBit;
+
+            return (Masks[wordIndex] & wordMask) != 0;
+        }
+
+        /// <summary>
+        /// Check if any bit in a range of bits in the bitmap are set. (inclusive)
+        /// </summary>
+        /// <param name="start">The first bit index to check</param>
+        /// <param name="end">The last bit index to check</param>
+        /// <returns>True if a bit is set, false otherwise</returns>
+        public bool IsSet(int start, int end)
+        {
+            if (start == end)
+            {
+                return IsSet(start);
+            }
+
+            int startIndex = start >> IntShift;
+            int startBit = start & IntMask;
+            long startMask = -1L << startBit;
+
+            int endIndex = end >> IntShift;
+            int endBit = end & IntMask;
+            long endMask = (long)(ulong.MaxValue >> (IntMask - endBit));
+
+            if (startIndex == endIndex)
+            {
+                return (Masks[startIndex] & startMask & endMask) != 0;
+            }
+
+            if ((Masks[startIndex] & startMask) != 0)
+            {
+                return true;
+            }
+
+            for (int i = startIndex + 1; i < endIndex; i++)
+            {
+                if (Masks[i] != 0)
+                {
+                    return true;
+                }
+            }
+
+            if ((Masks[endIndex] & endMask) != 0)
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Set a bit at a specific index to 1.
+        /// </summary>
+        /// <param name="bit">The bit index to set</param>
+        /// <returns>True if the bit is set, false if it was already set</returns>
+        public bool Set(int bit)
+        {
+            int wordIndex = bit >> IntShift;
+            int wordBit = bit & IntMask;
+
+            long wordMask = 1L << wordBit;
+
+            if ((Masks[wordIndex] & wordMask) != 0)
+            {
+                return false;
+            }
+
+            Masks[wordIndex] |= wordMask;
+
+            return true;
+        }
+
+        /// <summary>
+        /// Set a range of bits in the bitmap to 1.
+        /// </summary>
+        /// <param name="start">The first bit index to set</param>
+        /// <param name="end">The last bit index to set</param>
+        public void SetRange(int start, int end)
+        {
+            if (start == end)
+            {
+                Set(start);
+                return;
+            }
+
+            int startIndex = start >> IntShift;
+            int startBit = start & IntMask;
+            long startMask = -1L << startBit;
+
+            int endIndex = end >> IntShift;
+            int endBit = end & IntMask;
+            long endMask = (long)(ulong.MaxValue >> (IntMask - endBit));
+
+            if (startIndex == endIndex)
+            {
+                Masks[startIndex] |= startMask & endMask;
+            }
+            else
+            {
+                Masks[startIndex] |= startMask;
+
+                for (int i = startIndex + 1; i < endIndex; i++)
+                {
+                    Masks[i] |= -1;
+                }
+
+                Masks[endIndex] |= endMask;
+            }
+        }
+
+        /// <summary>
+        /// Clear a bit at a specific index to 0.
+        /// </summary>
+        /// <param name="bit">The bit index to clear</param>
+        /// <returns>True if the bit was set, false if it was not</returns>
+        public bool Clear(int bit)
+        {
+            int wordIndex = bit >> IntShift;
+            int wordBit = bit & IntMask;
+
+            long wordMask = 1L << wordBit;
+
+            bool wasSet = (Masks[wordIndex] & wordMask) != 0;
+
+            Masks[wordIndex] &= ~wordMask;
+
+            return wasSet;
+        }
+
+        /// <summary>
+        /// Clear the bitmap entirely, setting all bits to 0.
+        /// </summary>
+        public void Clear()
+        {
+            for (int i = 0; i < Masks.Length; i++)
+            {
+                Masks[i] = 0;
+            }
+        }
+    }
+}

--- a/Ryujinx.Memory/Tracking/ConcurrentBitmap.cs
+++ b/Ryujinx.Memory/Tracking/ConcurrentBitmap.cs
@@ -1,0 +1,161 @@
+﻿using System;
+using System.Threading;
+
+namespace Ryujinx.Memory.Tracking
+{
+    /// <summary>
+    /// A bitmap that can be safely modified from multiple threads.
+    /// </summary>
+    internal class ConcurrentBitmap
+    {
+        public const int IntSize = 64;
+
+        public const int IntShift = 6;
+        public const int IntMask = IntSize - 1;
+
+        /// <summary>
+        /// Masks representing the bitmap. Least significant bit first, 64-bits per mask.
+        /// </summary>
+        public readonly long[] Masks;
+
+        /// <summary>
+        /// Create a new multithreaded bitmap.
+        /// </summary>
+        /// <param name="count">The number of bits to reserve</param>
+        /// <param name="set">Whether the bits should be initially set or not</param>
+        public ConcurrentBitmap(int count, bool set)
+        {
+            Masks = new long[(count + IntMask) / IntSize];
+
+            if (set)
+            {
+                Array.Fill(Masks, -1L);
+            }
+        }
+
+        /// <summary>
+        /// Check if any bit in the bitmap is set.
+        /// </summary>
+        /// <returns>True if any bits are set, false otherwise</returns>
+        public bool AnySet()
+        {
+            for (int i = 0; i < Masks.Length; i++)
+            {
+                if (Volatile.Read(ref Masks[i]) != 0)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Check if a bit in the bitmap is set.
+        /// </summary>
+        /// <param name="bit">The bit index to check</param>
+        /// <returns>True if the bit is set, false otherwise</returns>
+        public bool IsSet(int bit)
+        {
+            int wordIndex = bit >> IntShift;
+            int wordBit = bit & IntMask;
+
+            long wordMask = 1L << wordBit;
+
+            return (Volatile.Read(ref Masks[wordIndex]) & wordMask) != 0;
+        }
+
+        /// <summary>
+        /// Check if any bit in a range of bits in the bitmap are set. (inclusive)
+        /// </summary>
+        /// <param name="start">The first bit index to check</param>
+        /// <param name="end">The last bit index to check</param>
+        /// <returns>True if a bit is set, false otherwise</returns>
+        public bool IsSet(int start, int end)
+        {
+            if (start == end)
+            {
+                return IsSet(start);
+            }
+
+            int startIndex = start >> IntShift;
+            int startBit = start & IntMask;
+            long startMask = -1L << startBit;
+
+            int endIndex = end >> IntShift;
+            int endBit = end & IntMask;
+            long endMask = (long)(ulong.MaxValue >> (IntMask - endBit));
+
+            long startValue = Volatile.Read(ref Masks[startIndex]);
+
+            if (startIndex == endIndex)
+            {
+                return (startValue & startMask & endMask) != 0;
+            }
+
+            if ((startValue & startMask) != 0)
+            {
+                return true;
+            }
+
+            for (int i = startIndex + 1; i < endIndex; i++)
+            {
+                if (Volatile.Read(ref Masks[i]) != 0)
+                {
+                    return true;
+                }
+            }
+
+            long endValue = Volatile.Read(ref Masks[endIndex]);
+
+            if ((endValue & endMask) != 0)
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Set a bit at a specific index to either true or false.
+        /// </summary>
+        /// <param name="bit">The bit index to set</param>
+        /// <param name="value">Whether the bit should be set or not</param>
+        public void Set(int bit, bool value)
+        {
+            int wordIndex = bit >> IntShift;
+            int wordBit = bit & IntMask;
+
+            long wordMask = 1L << wordBit;
+
+            long existing;
+            long newValue;
+
+            do
+            {
+                existing = Volatile.Read(ref Masks[wordIndex]);
+
+                if (value)
+                {
+                    newValue = existing | wordMask;
+                }
+                else
+                {
+                    newValue = existing & ~wordMask;
+                }
+            }
+            while (Interlocked.CompareExchange(ref Masks[wordIndex], newValue, existing) != existing);
+        }
+
+        /// <summary>
+        /// Clear the bitmap entirely, setting all bits to 0.
+        /// </summary>
+        public void Clear()
+        {
+            for (int i = 0; i < Masks.Length; i++)
+            {
+                Volatile.Write(ref Masks[i], 0);
+            }
+        }
+    }
+}

--- a/Ryujinx.Memory/Tracking/MemoryTracking.cs
+++ b/Ryujinx.Memory/Tracking/MemoryTracking.cs
@@ -177,6 +177,26 @@ namespace Ryujinx.Memory.Tracking
         }
 
         /// <summary>
+        /// Obtains a memory tracking handle for the given virtual region. This should be disposed when finished with.
+        /// </summary>
+        /// <param name="address">CPU virtual address of the region</param>
+        /// <param name="size">Size of the region</param>
+        /// <param name="bitmap">The bitmap owning the dirty flag for this handle</param>
+        /// <param name="bit">The bit of this handle within the dirty flag</param>
+        /// <returns>The memory tracking handle</returns>
+        internal RegionHandle BeginTrackingBitmap(ulong address, ulong size, ConcurrentBitmap bitmap, int bit)
+        {
+            (address, size) = PageAlign(address, size);
+
+            lock (TrackingLock)
+            {
+                RegionHandle handle = new RegionHandle(this, address, size, bitmap, bit, _memoryManager.IsRangeMapped(address, size));
+
+                return handle;
+            }
+        }
+
+        /// <summary>
         /// Signal that a virtual memory event happened at the given location (one byte).
         /// </summary>
         /// <param name="address">Virtual address accessed</param>

--- a/Ryujinx.Memory/Tracking/RegionHandle.cs
+++ b/Ryujinx.Memory/Tracking/RegionHandle.cs
@@ -1,5 +1,4 @@
-﻿using Ryujinx.Memory.Range;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -10,7 +9,7 @@ namespace Ryujinx.Memory.Tracking
     /// A tracking handle for a given region of virtual memory. The Dirty flag is updated whenever any changes are made,
     /// and an action can be performed when the region is read to or written from.
     /// </summary>
-    public class RegionHandle : IRegionHandle, IRange
+    public class RegionHandle : IRegionHandle
     {
         /// <summary>
         /// If more than this number of checks have been performed on a dirty flag since its last reprotect,
@@ -23,7 +22,20 @@ namespace Ryujinx.Memory.Tracking
         /// </summary>
         private static int VolatileThreshold = 5;
 
-        public bool Dirty { get; private set; }
+        public bool Dirty
+        {
+            get
+            {
+                return Bitmap.IsSet(DirtyBit);
+            }
+            protected set
+            {
+                Bitmap.Set(DirtyBit, value);
+            }
+        }
+
+        internal int SequenceNumber { get; set; }
+
         public bool Unmapped { get; private set; }
 
         public ulong Address { get; }
@@ -31,7 +43,6 @@ namespace Ryujinx.Memory.Tracking
         public ulong EndAddress { get; }
 
         internal IMultiRegionHandle Parent { get; set; }
-        internal int SequenceNumber { get; set; }
 
         private event Action _onDirty;
 
@@ -68,17 +79,26 @@ namespace Ryujinx.Memory.Tracking
 
         internal RegionSignal PreAction => _preAction;
 
+        internal ConcurrentBitmap Bitmap;
+        internal int DirtyBit;
+
         /// <summary>
-        /// Create a new region handle. The handle is registered with the given tracking object,
+        /// Create a new bitmap backed region handle. The handle is registered with the given tracking object,
         /// and will be notified of any changes to the specified region.
         /// </summary>
         /// <param name="tracking">Tracking object for the target memory block</param>
         /// <param name="address">Virtual address of the region to track</param>
         /// <param name="size">Size of the region to track</param>
+        /// <param name="bitmap">The bitmap the dirty flag for this handle is stored in</param>
+        /// <param name="bit">The bit index representing the dirty flag for this handle</param>
         /// <param name="mapped">True if the region handle starts mapped</param>
-        internal RegionHandle(MemoryTracking tracking, ulong address, ulong size, bool mapped = true)
+        internal RegionHandle(MemoryTracking tracking, ulong address, ulong size, ConcurrentBitmap bitmap, int bit, bool mapped = true)
         {
+            Bitmap = bitmap;
+            DirtyBit = bit;
+
             Dirty = mapped;
+
             Unmapped = !mapped;
             Address = address;
             Size = size;
@@ -90,6 +110,54 @@ namespace Ryujinx.Memory.Tracking
             {
                 region.Handles.Add(this);
             }
+        }
+
+        /// <summary>
+        /// Create a new region handle. The handle is registered with the given tracking object,
+        /// and will be notified of any changes to the specified region.
+        /// </summary>
+        /// <param name="tracking">Tracking object for the target memory block</param>
+        /// <param name="address">Virtual address of the region to track</param>
+        /// <param name="size">Size of the region to track</param>
+        /// <param name="mapped">True if the region handle starts mapped</param>
+        internal RegionHandle(MemoryTracking tracking, ulong address, ulong size, bool mapped = true)
+        {
+            Bitmap = new ConcurrentBitmap(1, mapped);
+
+            Unmapped = !mapped;
+            Address = address;
+            Size = size;
+            EndAddress = address + size;
+
+            _tracking = tracking;
+            _regions = tracking.GetVirtualRegionsForHandle(address, size);
+            foreach (var region in _regions)
+            {
+                region.Handles.Add(this);
+            }
+        }
+
+        /// <summary>
+        /// Replace the bitmap and bit index used to track dirty state.
+        /// </summary>
+        /// <remarks>
+        /// The tracking lock should be held when this is called, to ensure neither bitmap is modified.
+        /// </remarks>
+        /// <param name="bitmap">The bitmap the dirty flag for this handle is stored in</param>
+        /// <param name="bit">The bit index representing the dirty flag for this handle</param>
+        internal void ReplaceBitmap(ConcurrentBitmap bitmap, int bit)
+        {
+            // Assumes the tracking lock is held, so nothing else can signal right now.
+
+            var oldBitmap = Bitmap;
+            var oldBit = DirtyBit;
+
+            bitmap.Set(bit, Dirty);
+
+            Bitmap = bitmap;
+            DirtyBit = bit;
+
+            Dirty |= oldBitmap.IsSet(oldBit);
         }
 
         /// <summary>
@@ -108,7 +176,7 @@ namespace Ryujinx.Memory.Tracking
         public bool DirtyOrVolatile()
         {
             _checkCount++;
-            return Dirty || _volatile;
+            return _volatile || Dirty;
         }
 
         /// <summary>
@@ -195,6 +263,8 @@ namespace Ryujinx.Memory.Tracking
         /// </summary>
         public void ForceDirty()
         {
+            _checkCount++;
+
             Dirty = true;
         }
 


### PR DESCRIPTION
* Initial implementation

* Some improvements.

* Fix incorrect cast

* Performance improvement and improved correctness

* Add very fast path when all handles are checked.

* Slightly faster

* Add comment

* De-virtualize region handle

All region handles are now bitmap backed.

* Remove non-bitmap tracking

* Remove unused methods

* Add docs, remove unused methods

* Address Feedback

* Rename file